### PR TITLE
fix: Correct CORS to specific GitHub Pages URL and use auto-increment…

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for proper build numbering
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -44,8 +46,8 @@ jobs:
       - name: Get build number
         id: build_number
         run: |
-          # Get the current build number (number of commits on main branch)
-          BUILD_NUMBER=$(git rev-list --count HEAD)
+          # Use GitHub run number for auto-incrementing build number
+          BUILD_NUMBER=${{ github.run_number }}
           echo "BUILD_NUMBER=$BUILD_NUMBER" >> $GITHUB_OUTPUT
           echo "Build number: $BUILD_NUMBER"
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -39,14 +39,9 @@ class Settings(BaseSettings):
     log_level: str = "INFO"
     secret_key: str = "your-secret-key-change-in-production"
     
-    # CORS - Note: Origin is protocol + domain, NOT including path
+    # CORS - Production GitHub Pages URL
     cors_origins: List[str] = [
-        "http://localhost:3001", 
-        "http://127.0.0.1:3001",
-        "http://localhost:3000", 
-        "http://127.0.0.1:3000",
-        "https://imohweb.github.io",  # GitHub Pages (covers all paths under this domain)
-        "http://imohweb.github.io"    # GitHub Pages HTTP fallback
+        "https://imohweb.github.io/AI-Powered-certifications-exams-practice-questions",
     ]
     
     # Rate Limiting


### PR DESCRIPTION
… build numbers

CORS Changes:
- Set CORS to exact frontend URL: https://imohweb.github.io/AI-Powered-certifications-exams-practice-questions
- Remove localhost URLs (not needed in production)
- Prevents CORS conflicts with other apps on same GitHub Pages domain

Build Number Changes:
- Use GitHub run_number for auto-incrementing build numbers (1, 2, 3, etc.)
- Each workflow run gets unique incrementing number
- Simpler and more reliable than commit counting or timestamps